### PR TITLE
新增 Event 模块及测试文件

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,16 @@
  * @Author: Russ Zhong 
  * @Date: 2018-12-10 16:36:33 
  * @Last Modified by: Russ Zhong
- * @Last Modified time: 2018-12-17 14:37:50
+ * @Last Modified time: 2018-12-17 21:12:36
  */
 
 const _Util = require('./packages/Util');
 const _Number = require('./packages/Number');
 const _String = require('./packages/String');
 const _Array = require('./packages/Array');
+const _Event = require('./packages/Event');
 const { mixin, each, isUndefined } = _Util;
-const modules = [_Util, _Number, _String, _Array];         // Bind modules to Jerry.
+const modules = [_Util, _Number, _String, _Array, _Event];         // Bind modules to Jerry.
 const { slice } = require('./utils');
 const { version } = require('../package.json');
 

--- a/src/packages/Event.js
+++ b/src/packages/Event.js
@@ -1,0 +1,57 @@
+/*
+ * @Author: Russ Zhong 
+ * @Date: 2018-12-17 20:26:51 
+ * @Last Modified by: Russ Zhong
+ * @Last Modified time: 2018-12-17 21:21:54
+ */
+
+const { isInBrowser } = require('../utils');
+const { each } = require('./Util');
+
+function addEvent(el, eventType, callback) {
+  if (!isInBrowser()) return;
+  if (!!window.addEventListener) {
+    el.addEventListener(eventType, callback);
+  } else if (!!window.attachEvent) {
+    el.attachEvent('on' + eventType, callback);
+  } else {
+    el['on' + eventType] = callback;
+  }
+}
+
+function removeEvent(el, eventType, callback) {
+  if (!isInBrowser()) return;
+  if (!!window.removeEventListener) {
+    el.removeEventListener(eventType, callback);
+  } else if (!!window.detachEvent) {
+    el.detachEvent('on' + eventType, callback);
+  } else {
+    el['on' + eventType] = callback;
+  }
+}
+
+class CustomEvents {
+  constructor() {
+    this.callbacks = {};
+  }
+  subscribe(eventType, callback) {
+    this.callbacks[eventType] ? this.callbacks[eventType].push(callback) : this.callbacks[eventType] = [callback];
+  }
+  dispatch(eventType, data) {
+    let e = {
+      eventType,
+      data
+    };
+    each(this.callbacks[eventType], callback => callback(e));
+  }
+  unsubscribe(eventType, callback) {
+    let idx = this.callbacks[eventType].indexOf(callback);
+    this.callbacks[eventType].splice(idx, 1);
+  }
+}
+
+module.exports = {
+  addEvent,
+  removeEvent,
+  CustomEvents
+};

--- a/test/Event.test.js
+++ b/test/Event.test.js
@@ -1,0 +1,32 @@
+/*
+ * @Author: Russ Zhong 
+ * @Date: 2018-12-17 21:18:24 
+ * @Last Modified by: Russ Zhong
+ * @Last Modified time: 2018-12-17 21:27:29
+ */
+
+const {
+  CustomEvents
+} = require('../src/packages/Event');
+const expect = require('expect.js');
+
+describe('*************************************测试 Event *************************************', function() {
+  describe('测试 CustomEvent', function() {
+    it('#事件的订阅、发布、取消订阅', function(done) {
+      const EE = new CustomEvents();
+      const cb = function(e) {
+        expect(e.eventType).to.be('mocha');
+        expect(e.data).to.be('test!');
+      };
+      EE.subscribe('mocha', cb);
+      setTimeout(() => {
+        EE.dispatch('mocha', 'test!');
+        setTimeout(() => {
+          EE.unsubscribe('mocha', cb);
+          expect(EE.callbacks['mocha'].length).to.be(0);
+          done();
+        }, 200);
+      }, 200);
+    });
+  });
+});


### PR DESCRIPTION
## 简介

新增了 Event 模块及测试文件，功能包括
*	兼容 IE < 9 的 addEvent 事件绑定函数
*	兼容	IE < 9 的 removeEvent 事件解绑函数
*	支持自定义事件，类似 Node 的 EventEmitter

## 注意点
*	文档未更新
*	单个事件多个处理函数的场景已经在浏览器中测试过了，所以未添加到单元测试案例中
